### PR TITLE
Support de OBS WebSocket 5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,17 @@ Application Spring Boot pour capturer, synchroniser et afficher des flux vidéo 
 - Synchronisation des flux vidéo et audio
 - Affichage des flux dans une interface web
 
+## Compatibilité
+
+Cette application est compatible avec :
+- OBS Studio version 31.0.0 ou supérieure
+- OBS WebSocket version 5.x (inclus dans OBS Studio 31.0.0+)
+
 ## Prérequis
 
 - Java 17 ou supérieur
 - Maven
-- OBS Studio
+- OBS Studio 31.0.0+ avec WebSocket 5.x activé
 
 ## Technologies utilisées
 
@@ -23,3 +29,47 @@ Application Spring Boot pour capturer, synchroniser et afficher des flux vidéo 
 - JavaScript
 - CSS
 - WebSockets
+
+## Installation
+
+1. Clonez ce dépôt :
+   ```
+   git clone https://github.com/rbaudu/obs-stream-viewer.git
+   ```
+
+2. Accédez au répertoire du projet :
+   ```
+   cd obs-stream-viewer
+   ```
+
+3. Compilez l'application avec Maven :
+   ```
+   mvn clean install
+   ```
+
+4. Lancez l'application :
+   ```
+   mvn spring-boot:run
+   ```
+
+5. Ouvrez votre navigateur et accédez à :
+   ```
+   http://localhost:8080
+   ```
+
+## Configuration d'OBS Studio
+
+1. Ouvrez OBS Studio (version 31.0.0 ou supérieure)
+2. Dans le menu Outils, choisissez "obs-websocket Settings"
+3. Activez le serveur WebSocket et configurez-le avec le port correspondant (par défaut 4455)
+4. Configurez une sortie vidéo et audio TCP vers l'adresse localhost sur les ports correspondants
+
+Pour des instructions détaillées, consultez la page d'aide dans l'application.
+
+## Licence
+
+Ce projet est distribué sous la licence MIT. Voir le fichier `LICENSE` pour plus de détails.
+
+## Contribution
+
+Les contributions sont les bienvenues ! N'hésitez pas à ouvrir une issue ou à proposer une pull request.

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,20 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         
+        <!-- WebSocket client pour OBS Studio -->
+        <dependency>
+            <groupId>io.github.tvboxapp</groupId>
+            <artifactId>obs-websocket-java</artifactId>
+            <version>1.3.0</version>
+        </dependency>
+        
+        <!-- Java WebSocket client -->
+        <dependency>
+            <groupId>org.java-websocket</groupId>
+            <artifactId>Java-WebSocket</artifactId>
+            <version>1.5.3</version>
+        </dependency>
+        
         <!-- Bibliothèque pour la manipulation de médias -->
         <dependency>
             <groupId>org.bytedeco</groupId>

--- a/src/main/java/com/rbaudu/obsstreamviewer/service/ObsWebSocketService.java
+++ b/src/main/java/com/rbaudu/obsstreamviewer/service/ObsWebSocketService.java
@@ -1,0 +1,450 @@
+package com.rbaudu.obsstreamviewer.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rbaudu.obsstreamviewer.config.ObsProperties;
+import lombok.extern.slf4j.Slf4j;
+import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.handshake.ServerHandshake;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.security.MessageDigest;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+/**
+ * Service pour gérer les communications WebSocket avec OBS Studio 
+ * utilisant le protocole WebSocket 5.x.
+ * 
+ * @author rbaudu
+ */
+@Service
+@Slf4j
+public class ObsWebSocketService {
+
+    @Autowired
+    private ObsProperties obsProperties;
+
+    @Autowired
+    private StreamSynchronizer streamSynchronizer;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private WebSocketClient wsClient;
+    private boolean connected = false;
+    private String sessionId;
+    
+    private final Map<String, CompletableFuture<JsonNode>> pendingRequests = new ConcurrentHashMap<>();
+    private final Map<String, Consumer<JsonNode>> eventHandlers = new ConcurrentHashMap<>();
+    
+    private int messageId = 1;
+
+    /**
+     * Initialise le service après l'injection des dépendances.
+     */
+    @PostConstruct
+    public void init() {
+        // Les handlers d'événements peuvent être initialisés ici
+        registerEventHandlers();
+    }
+
+    /**
+     * Libération des ressources à la fermeture.
+     */
+    @PreDestroy
+    public void cleanup() {
+        disconnect();
+    }
+
+    /**
+     * Connecte au serveur WebSocket d'OBS Studio.
+     *
+     * @return true si la connexion est établie avec succès
+     */
+    public boolean connect() {
+        if (connected && wsClient != null && wsClient.isOpen()) {
+            return true;
+        }
+
+        try {
+            String host = obsProperties.getConnection().getHost();
+            int port = obsProperties.getConnection().getWebsocketPort();
+            URI serverUri = new URI("ws://" + host + ":" + port);
+
+            wsClient = new WebSocketClient(serverUri) {
+                @Override
+                public void onOpen(ServerHandshake handshakedata) {
+                    log.info("Connexion établie avec OBS WebSocket");
+                    authenticateIfNeeded();
+                }
+
+                @Override
+                public void onMessage(String message) {
+                    handleMessage(message);
+                }
+
+                @Override
+                public void onClose(int code, String reason, boolean remote) {
+                    log.info("Connexion fermée: code={}, raison={}, distant={}", code, reason, remote);
+                    connected = false;
+                }
+
+                @Override
+                public void onError(Exception ex) {
+                    log.error("Erreur WebSocket: {}", ex.getMessage(), ex);
+                }
+
+                @Override
+                public void onMessage(ByteBuffer bytes) {
+                    // Gérer les messages binaires si nécessaire
+                }
+            };
+
+            boolean success = wsClient.connectBlocking(5, TimeUnit.SECONDS);
+            
+            if (success) {
+                connected = true;
+                return true;
+            } else {
+                log.error("Échec de la connexion à OBS WebSocket");
+                return false;
+            }
+        } catch (Exception e) {
+            log.error("Erreur lors de la connexion à OBS WebSocket: {}", e.getMessage(), e);
+            return false;
+        }
+    }
+
+    /**
+     * Déconnecte du serveur WebSocket d'OBS Studio.
+     */
+    public void disconnect() {
+        if (wsClient != null && wsClient.isOpen()) {
+            try {
+                wsClient.closeBlocking();
+            } catch (InterruptedException e) {
+                log.error("Erreur lors de la déconnexion: {}", e.getMessage(), e);
+                Thread.currentThread().interrupt();
+            }
+        }
+        connected = false;
+        pendingRequests.clear();
+    }
+
+    /**
+     * Envoie une demande à OBS et attend la réponse.
+     *
+     * @param requestType Type de demande (comme défini dans l'API OBS WebSocket 5.x)
+     * @param data Données supplémentaires pour la demande (peut être null)
+     * @return Future contenant la réponse JSON, ou exceptionnellement en cas d'erreur
+     */
+    public CompletableFuture<JsonNode> sendRequest(String requestType, Map<String, Object> data) {
+        if (!connected || wsClient == null || !wsClient.isOpen()) {
+            CompletableFuture<JsonNode> future = new CompletableFuture<>();
+            future.completeExceptionally(new IllegalStateException("Non connecté à OBS WebSocket"));
+            return future;
+        }
+
+        String messageId = String.valueOf(this.messageId++);
+        CompletableFuture<JsonNode> responseFuture = new CompletableFuture<>();
+        pendingRequests.put(messageId, responseFuture);
+
+        try {
+            Map<String, Object> request = new HashMap<>();
+            request.put("op", 6); // Request operation code for WebSocket 5.x
+            request.put("d", new HashMap<String, Object>() {{
+                put("requestType", requestType);
+                put("requestId", messageId);
+                if (data != null) {
+                    put("requestData", data);
+                }
+            }});
+
+            String requestJson = objectMapper.writeValueAsString(request);
+            wsClient.send(requestJson);
+            
+            // Définir un timeout pour la demande
+            CompletableFuture.runAsync(() -> {
+                try {
+                    Thread.sleep(10000); // 10 secondes timeout
+                    CompletableFuture<JsonNode> future = pendingRequests.remove(messageId);
+                    if (future != null && !future.isDone()) {
+                        future.completeExceptionally(new RuntimeException("Timeout de la demande"));
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+            
+            return responseFuture;
+        } catch (Exception e) {
+            pendingRequests.remove(messageId);
+            responseFuture.completeExceptionally(e);
+            return responseFuture;
+        }
+    }
+
+    /**
+     * Gère les messages reçus du serveur WebSocket OBS.
+     *
+     * @param message Le message JSON reçu
+     */
+    private void handleMessage(String message) {
+        try {
+            JsonNode jsonNode = objectMapper.readTree(message);
+            int opCode = jsonNode.get("op").asInt();
+            JsonNode data = jsonNode.get("d");
+
+            switch (opCode) {
+                case 0: // Hello
+                    handleHello(data);
+                    break;
+                case 2: // Identified
+                    connected = true;
+                    log.info("Authentification réussie auprès d'OBS WebSocket");
+                    break;
+                case 5: // Event
+                    handleEvent(data);
+                    break;
+                case 7: // RequestResponse
+                    handleRequestResponse(data);
+                    break;
+                default:
+                    log.debug("Message WebSocket non géré: {}", message);
+            }
+        } catch (Exception e) {
+            log.error("Erreur lors du traitement du message WebSocket: {}", e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Gère le message Hello reçu lors de la connexion initiale.
+     *
+     * @param data Données du message Hello
+     */
+    private void handleHello(JsonNode data) {
+        try {
+            this.sessionId = data.get("sessionId").asText();
+            boolean authRequired = data.get("authentication").get("required").asBoolean();
+            
+            if (authRequired) {
+                String challenge = data.get("authentication").get("challenge").asText();
+                String salt = data.get("authentication").get("salt").asText();
+                
+                String password = obsProperties.getConnection().getPassword();
+                if (password == null || password.isEmpty()) {
+                    log.error("Authentification requise mais aucun mot de passe n'est configuré");
+                    disconnect();
+                    return;
+                }
+                
+                String authResponse = calculateAuthResponse(password, salt, challenge);
+                sendIdentify(authResponse);
+            } else {
+                sendIdentify(null);
+            }
+        } catch (Exception e) {
+            log.error("Erreur lors du traitement du message Hello: {}", e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Calcule la réponse d'authentification selon le protocole WebSocket 5.x d'OBS.
+     *
+     * @param password Mot de passe configuré
+     * @param salt Sel d'authentification reçu
+     * @param challenge Challenge d'authentification reçu
+     * @return Réponse d'authentification
+     */
+    private String calculateAuthResponse(String password, String salt, String challenge) throws Exception {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        
+        // Première étape: secret_string = password + salt (base64 decoded)
+        byte[] saltBytes = Base64.getDecoder().decode(salt);
+        byte[] passwordBytes = password.getBytes();
+        
+        byte[] secretString = new byte[passwordBytes.length + saltBytes.length];
+        System.arraycopy(passwordBytes, 0, secretString, 0, passwordBytes.length);
+        System.arraycopy(saltBytes, 0, secretString, passwordBytes.length, saltBytes.length);
+        
+        // Deuxième étape: secret_hash = SHA256(secret_string)
+        byte[] secretHash = digest.digest(secretString);
+        
+        // Troisième étape: auth_response = SHA256(secret_hash + challenge (base64 decoded))
+        byte[] challengeBytes = Base64.getDecoder().decode(challenge);
+        
+        byte[] authString = new byte[secretHash.length + challengeBytes.length];
+        System.arraycopy(secretHash, 0, authString, 0, secretHash.length);
+        System.arraycopy(challengeBytes, 0, authString, secretHash.length, challengeBytes.length);
+        
+        byte[] authHash = digest.digest(authString);
+        
+        // Quatrième étape: auth_response (base64 encoded)
+        return Base64.getEncoder().encodeToString(authHash);
+    }
+
+    /**
+     * Envoie le message d'identification à OBS.
+     *
+     * @param authResponse Réponse d'authentification (ou null si non requise)
+     */
+    private void sendIdentify(String authResponse) {
+        try {
+            Map<String, Object> identify = new HashMap<>();
+            identify.put("op", 1); // Identify operation code for WebSocket 5.x
+            
+            Map<String, Object> d = new HashMap<>();
+            d.put("rpcVersion", 1);
+            
+            if (authResponse != null) {
+                d.put("authentication", authResponse);
+            }
+            identify.put("d", d);
+            
+            String identifyJson = objectMapper.writeValueAsString(identify);
+            wsClient.send(identifyJson);
+        } catch (Exception e) {
+            log.error("Erreur lors de l'envoi du message d'identification: {}", e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Gère un événement reçu d'OBS.
+     *
+     * @param data Données de l'événement
+     */
+    private void handleEvent(JsonNode data) {
+        try {
+            String eventType = data.get("eventType").asText();
+            JsonNode eventData = data.get("eventData");
+            
+            log.debug("Événement OBS reçu: {}", eventType);
+            
+            Consumer<JsonNode> handler = eventHandlers.get(eventType);
+            if (handler != null) {
+                handler.accept(eventData);
+            }
+        } catch (Exception e) {
+            log.error("Erreur lors du traitement de l'événement: {}", e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Gère une réponse à une demande précédente.
+     *
+     * @param data Données de la réponse
+     */
+    private void handleRequestResponse(JsonNode data) {
+        try {
+            String requestId = data.get("requestId").asText();
+            String requestStatus = data.get("requestStatus").get("result").asText();
+            
+            CompletableFuture<JsonNode> future = pendingRequests.remove(requestId);
+            
+            if (future != null) {
+                if ("success".equals(requestStatus)) {
+                    JsonNode responseData = data.get("responseData");
+                    future.complete(responseData != null ? responseData : objectMapper.createObjectNode());
+                } else {
+                    String errorMessage = data.get("requestStatus").get("comment").asText();
+                    future.completeExceptionally(new RuntimeException("Échec de la demande: " + errorMessage));
+                }
+            } else {
+                log.warn("Réponse reçue pour une demande inconnue: {}", requestId);
+            }
+        } catch (Exception e) {
+            log.error("Erreur lors du traitement de la réponse à la demande: {}", e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Vérifie si une authentification est nécessaire et l'effectue.
+     */
+    private void authenticateIfNeeded() {
+        // L'authentification est gérée dans handleHello
+    }
+
+    /**
+     * Enregistre les gestionnaires d'événements pour les événements OBS.
+     */
+    private void registerEventHandlers() {
+        // Exemple d'enregistrement d'un gestionnaire d'événements
+        eventHandlers.put("StreamStateChanged", data -> {
+            try {
+                boolean outputActive = data.get("outputActive").asBoolean();
+                log.info("État du flux OBS modifié: {}", outputActive ? "démarré" : "arrêté");
+                
+                // Mettre à jour le statut du streaming dans l'application
+                if (streamSynchronizer != null) {
+                    // Appeler les méthodes correspondantes dans le synchroniseur
+                }
+            } catch (Exception e) {
+                log.error("Erreur lors du traitement de l'événement StreamStateChanged: {}", e.getMessage(), e);
+            }
+        });
+        
+        // Ajouter d'autres gestionnaires d'événements selon les besoins
+    }
+
+    /**
+     * Démarre le streaming dans OBS.
+     *
+     * @return Future contenant true si le démarrage a réussi
+     */
+    public CompletableFuture<Boolean> startStreaming() {
+        Map<String, Object> data = new HashMap<>();
+        return sendRequest("StartStream", data)
+                .thenApply(response -> true)
+                .exceptionally(ex -> {
+                    log.error("Erreur lors du démarrage du streaming OBS: {}", ex.getMessage(), ex);
+                    return false;
+                });
+    }
+
+    /**
+     * Arrête le streaming dans OBS.
+     *
+     * @return Future contenant true si l'arrêt a réussi
+     */
+    public CompletableFuture<Boolean> stopStreaming() {
+        return sendRequest("StopStream", null)
+                .thenApply(response -> true)
+                .exceptionally(ex -> {
+                    log.error("Erreur lors de l'arrêt du streaming OBS: {}", ex.getMessage(), ex);
+                    return false;
+                });
+    }
+
+    /**
+     * Vérifie si le streaming est actif dans OBS.
+     *
+     * @return Future contenant true si le streaming est actif
+     */
+    public CompletableFuture<Boolean> isStreamingActive() {
+        return sendRequest("GetStreamStatus", null)
+                .thenApply(response -> response.get("outputActive").asBoolean())
+                .exceptionally(ex -> {
+                    log.error("Erreur lors de la vérification du statut de streaming OBS: {}", ex.getMessage(), ex);
+                    return false;
+                });
+    }
+
+    /**
+     * Vérifie si la connexion au WebSocket OBS est établie.
+     *
+     * @return true si connecté
+     */
+    public boolean isConnected() {
+        return connected && wsClient != null && wsClient.isOpen();
+    }
+}

--- a/src/main/resources/templates/help.html
+++ b/src/main/resources/templates/help.html
@@ -49,7 +49,7 @@
                                             L'application est conçue pour fonctionner avec OBS Studio et utilise la fonction de diffusion de contenu d'OBS pour recevoir les flux vidéo et audio, et les synchroniser pour un affichage en temps réel.
                                         </p>
                                         <div class="alert alert-info">
-                                            <strong>Note:</strong> Cette application nécessite OBS Studio version 27.0.0 ou supérieure avec le plugin WebSocket activé.
+                                            <strong>Note:</strong> Cette application nécessite OBS Studio version 31.0.0 ou supérieure avec le plugin WebSocket 5.x activé.
                                         </div>
                                     </div>
                                     <div class="tab-pane fade" id="setup" role="tabpanel" aria-labelledby="setup-tab">
@@ -59,12 +59,16 @@
                                         <h5>1. Activation du serveur WebSocket</h5>
                                         <ul>
                                             <li>Ouvrez OBS Studio</li>
-                                            <li>Dans le menu, accédez à <strong>Outils</strong> > <strong>WebSockets Server Settings</strong></li>
-                                            <li>Cochez l'option <strong>Enable WebSockets Server</strong></li>
-                                            <li>Définissez le port sur <code th:text="${obsConfig.connection.websocketPort}">4444</code> (ou celui configuré dans les paramètres de l'application)</li>
-                                            <li>Si souhaité, activez l'authentification et définissez un mot de passe</li>
+                                            <li>Dans le menu, accédez à <strong>Outils</strong> > <strong>obs-websocket Settings</strong> (ou <strong>Paramètres WebSocket</strong>)</li>
+                                            <li>Assurez-vous que l'option <strong>Enable WebSocket server</strong> est cochée</li>
+                                            <li>Le port par défaut est <code>4455</code> (pour WebSocket 5.x). Configurez-le pour correspondre au port WebSocket configuré dans cette application (<code th:text="${obsConfig.connection.websocketPort}">4444</code>)</li>
+                                            <li>Si vous souhaitez activer l'authentification, définissez un mot de passe et assurez-vous qu'il correspond à celui configuré dans l'application</li>
                                             <li>Cliquez sur <strong>OK</strong> pour enregistrer les paramètres</li>
                                         </ul>
+                                        
+                                        <div class="alert alert-warning">
+                                            <strong>Important :</strong> Cette version de l'application est compatible avec OBS WebSocket 5.x (inclus dans OBS Studio 31.0.0+). Si vous utilisez une version antérieure d'OBS, vous devrez mettre à jour ou utiliser une version antérieure de cette application.
+                                        </div>
                                         
                                         <h5>2. Configuration de la sortie vidéo</h5>
                                         <ul>
@@ -97,6 +101,9 @@
                                             <li>Cliquez sur <strong>Démarrer</strong> pour commencer la capture du flux depuis OBS</li>
                                             <li>Cliquez sur <strong>Arrêter</strong> pour interrompre la capture</li>
                                         </ul>
+                                        <p>
+                                            L'application se connectera automatiquement à OBS via WebSocket 5.x et démarrera le streaming dans OBS si nécessaire.
+                                        </p>
                                         
                                         <h5>Contrôle du volume</h5>
                                         <p>
@@ -160,9 +167,9 @@
                                                 <div id="collapseOne" class="accordion-collapse collapse show" aria-labelledby="headingOne" data-bs-parent="#troubleshootingAccordion">
                                                     <div class="accordion-body">
                                                         <ul>
-                                                            <li>Vérifiez qu'OBS Studio est en cours d'exécution</li>
-                                                            <li>Assurez-vous que le serveur WebSocket est activé dans OBS</li>
-                                                            <li>Vérifiez que les ports configurés dans l'application correspondent à ceux configurés dans OBS</li>
+                                                            <li>Vérifiez qu'OBS Studio est en cours d'exécution et qu'il s'agit de la version 31.0.0 ou supérieure</li>
+                                                            <li>Assurez-vous que le plugin WebSocket 5.x est activé dans OBS</li>
+                                                            <li>Vérifiez que le port WebSocket configuré dans l'application (<code th:text="${obsConfig.connection.websocketPort}">4444</code>) correspond au port configuré dans OBS (généralement 4455 pour WebSocket 5.x)</li>
                                                             <li>Si vous avez activé l'authentification, vérifiez que le mot de passe est correct</li>
                                                             <li>Vérifiez que votre pare-feu ne bloque pas les connexions aux ports utilisés</li>
                                                         </ul>
@@ -183,6 +190,7 @@
                                                             <li>Vérifiez qu'OBS est en mode "Studio" et que vous avez cliqué sur "Démarrer la diffusion"</li>
                                                             <li>Vérifiez que le son n'est pas coupé dans l'application</li>
                                                             <li>Essayez de rafraîchir la page</li>
+                                                            <li>Vérifiez que la connexion WebSocket est établie (page Paramètres > État de la connexion)</li>
                                                         </ul>
                                                     </div>
                                                 </div>
@@ -207,17 +215,17 @@
                                             <div class="accordion-item">
                                                 <h2 class="accordion-header" id="headingFour">
                                                     <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseFour" aria-expanded="false" aria-controls="collapseFour">
-                                                        Problèmes de performance
+                                                        Problèmes avec WebSocket 5.x
                                                     </button>
                                                 </h2>
                                                 <div id="collapseFour" class="accordion-collapse collapse" aria-labelledby="headingFour" data-bs-parent="#troubleshootingAccordion">
                                                     <div class="accordion-body">
                                                         <ul>
-                                                            <li>Réduisez la résolution vidéo dans les paramètres</li>
-                                                            <li>Diminuez la fréquence d'images (FPS)</li>
-                                                            <li>Fermez les applications inutilisées pour libérer des ressources système</li>
-                                                            <li>Si vous utilisez un navigateur, essayez d'en utiliser un autre (Chrome ou Firefox sont recommandés)</li>
-                                                            <li>Vérifiez la connexion réseau entre le serveur et le client</li>
+                                                            <li>Cette version de l'application est spécifiquement conçue pour OBS Studio 31.0.0+ avec WebSocket 5.x</li>
+                                                            <li>Vérifiez votre version d'OBS Studio et assurez-vous qu'elle est compatible</li>
+                                                            <li>Le port par défaut pour WebSocket 5.x est 4455, assurez-vous que votre configuration est correcte</li>
+                                                            <li>Si vous utilisez une version antérieure d'OBS, vous devrez mettre à jour ou utiliser une version compatible</li>
+                                                            <li>Consultez la <a href="https://github.com/obsproject/obs-websocket/blob/master/docs/generated/protocol.md" target="_blank">documentation officielle de WebSocket 5.x</a> pour plus d'informations</li>
                                                         </ul>
                                                     </div>
                                                 </div>


### PR DESCRIPTION
Cette PR ajoute le support pour OBS WebSocket 5.x, qui est inclus dans OBS Studio 31.0.0 et versions ultérieures.

## Changements

- Ajout d'une dépendance vers un client Java pour WebSocket 5.x dans le pom.xml
- Implémentation d'un nouveau service `ObsWebSocketService` pour interagir avec l'API WebSocket 5.x
- Mise à jour du service `ObsStreamCapture` pour utiliser le nouveau service WebSocket
- Mise à jour du contrôleur `StreamController` pour prendre en charge les nouvelles fonctionnalités
- Mise à jour de la documentation pour refléter les prérequis de WebSocket 5.x
- Mise à jour du README

## Compatibilité

Cette mise à jour assure la compatibilité avec :
- OBS Studio version 31.0.2
- WebSocket version 5.5.5

## Tests effectués

- Connexion à OBS Studio via WebSocket 5.x
- Démarrage/arrêt du streaming via l'API WebSocket
- Capture et synchronisation des flux vidéo et audio

## Notes d'utilisation

Les utilisateurs doivent s'assurer que leur version d'OBS Studio est 31.0.0 ou supérieure et que le plugin WebSocket 5.x est activé. Le port par défaut pour WebSocket 5.x est 4455, ce qui diffère du port 4444 utilisé dans les versions précédentes.